### PR TITLE
Adding basic Makefile commands

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,9 @@
+### Documentation available at https://github.com/ho-nl/docker-development-box
+### Changelog can be found at https://github.com/ho-nl/docker-development-box/releases
+
+### PROJECT SETTINGS
+
+PROJECT_NAME=blabla_magento
+PROJECT_BASE_URL=blabla.localhost.reachdigital.io
+
+## TODO: move more settings from docker-compose to the .env file

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,1 @@
+include docker.mk

--- a/docker.mk
+++ b/docker.mk
@@ -1,0 +1,63 @@
+include .env
+
+default: up
+
+## help	:	Print commands help.
+.PHONY: help
+ifneq (,$(wildcard docker.mk))
+help : docker.mk
+	@sed -n 's/^##//p' $<
+else
+help : Makefile
+	@sed -n 's/^##//p' $<
+endif
+
+## up	:	Start up containers.
+.PHONY: up
+up:
+	@echo "Starting up containers for $(PROJECT_NAME)..."
+	docker-compose pull
+	docker-compose up -d --remove-orphans
+
+## down	:	Stop containers.
+.PHONY: down
+down: stop
+
+## start	:	Start containers without updating.
+.PHONY: start
+start:
+	@echo "Starting containers for $(PROJECT_NAME) from where you left off..."
+	@docker-compose start
+
+## stop	:	Stop containers.
+.PHONY: stop
+stop:
+	@echo "Stopping containers for $(PROJECT_NAME)..."
+	@docker-compose stop
+
+## prune	:	Remove containers and their volumes.
+##		You can optionally pass an argument with the service name to prune single container
+##		prune mariadb	: Prune `mariadb` container and remove its volumes.
+##		prune mariadb solr	: Prune `mariadb` and `solr` containers and remove their volumes.
+.PHONY: prune
+prune:
+	@echo "Removing containers for $(PROJECT_NAME)..."
+	@docker-compose down -v $(filter-out $@,$(MAKECMDGOALS))
+
+## ps	:	List running containers.
+.PHONY: ps
+ps:
+	@docker ps --filter name='$(PROJECT_NAME)*'
+
+## logs	:	View containers logs.
+##		You can optinally pass an argument with the service name to limit logs
+##		logs php	: View `php` container logs.
+##		logs nginx php	: View `nginx` and `php` containers logs.
+.PHONY: logs
+logs:
+	@docker-compose logs -f $(filter-out $@,$(MAKECMDGOALS))
+
+
+# https://stackoverflow.com/a/6273809/1826109
+%:
+	@:


### PR DESCRIPTION
As suggested in https://github.com/ho-nl/docker-development-box/issues/19, an idea to add some helpers, scripts or anything that can be useful while developing.

Code/markup taken from https://github.com/wodby/docker4drupal/blob/dc413035c05d92a4aec3cc092cf27ef246937a2c/docker.mk (MIT license)

Basic commands added:
- up
- help
- down
- start (up)
- stop (down)
- prune
- ps
- logs

TODO:
- use the environment variables in `.env`
- move environment variables now hardcoded to `.env`
- connect with locally running php (replacing the original docker4drupal commands that run into the container by the native commands)

And also, as mentioned in https://github.com/ho-nl/docker-development-box/issues/19#issuecomment-637763278 by @paales :
- ssh: See README
- cli: since php is running locally, everything can start locally

But before I implement all the commands, I can already show the idea and get some feedback before finishing them all.