### PR TITLE
install native imagick. It's required to display the template path hints

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -136,6 +136,9 @@ install_php() {
   cp -rp /usr/local/etc/php/"$PHPVERSION"/php-fpm.d /usr/local/etc/php/"$PHPVERSION"/php-fpm-xdebug.d
   sed -i '' "s/^listen = 127.0.0.1:$PHPFPM/listen = 127.0.0.1:$XPHPFPM/g" /usr/local/etc/php/"$PHPVERSION"/php-fpm-xdebug.d/www.conf
 
+  echo "Installing Imagick for PHP"
+  pecl install imagick
+
   echo "[$PHP] ✅ Installed"
   echo ""
 }


### PR DESCRIPTION
If you don't have natively installed Imagemagick on your machine, you can not use for example the template path hints. Maybe you want to add this to your install.sh