### PR TITLE
fix: mysqldump fails due to COLUMN_STATISTICS

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -233,10 +233,10 @@ done
 
 echo "
 Installing mysql-client, gnu-sed, pv, jq"
-brew install gnu-sed mysql-client pv jq &>/dev/null &
+brew install gnu-sed mysql-client@5.7 pv jq &>/dev/null &
 spinner
 
-brew link mysql-client --force &>/dev/null &
+brew link mysql-client@5.7 --force &>/dev/null &
 spinner
 
 echo "


### PR DESCRIPTION
Matches the mysql-client version with the mysql server version to resolve the missing COLUMN_STATISTICS table when dumping a database.

This fixes #36 