### PR TITLE
fix: changed php into php@7.4

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # If you're adding a new version, you need an additional XDEBUG version, not retrieved dynamically.
-PHPS='php@7.2 php@7.3 php'
+PHPS='php@7.2 php@7.3 php7.4'
 
 spinner() {
   local pid=$!


### PR DESCRIPTION
After the release of php 8.0 php@7.4 needs to be defined otherwise it won't be installed.
And if installed wil give an port already in use error.