### PR TITLE
Change DB user to root

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ You are now done with the global installation 🎉
   ```
     'host' => '127.0.0.1',
     'dbname' => 'magento',
-    'username' => 'magento',
+    'username' => 'root',
     'password' => 'magento',
   ```
 - Create a setup script for the base-urls and run it.


### PR DESCRIPTION
Using root as DB user avoids a (possibly harmless) error when making DB dumps about lacking a PROCESS privilege (`'Access denied; you need (at least one of) the PROCESS privilege(s) for this operation'`), and gives more certainty about just having made a successful and complete dump of your database.