### PR TITLE
feat: increase nginx map hash limit

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -22,6 +22,9 @@ http {
 
     keepalive_timeout  65;
 
+    map_hash_max_size 1024;
+    map_hash_bucket_size 1024;
+
     #gzip  on;
 
     include /etc/nginx/conf.d/*.conf;


### PR DESCRIPTION
ran into limits when adding a custom map, this prevents the following error:
could not build map_hash, you should increase map_hash_bucket_size: 64