### PR TITLE
Fix install.sh oneliner

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ locally.
 ```bash
 # Magento 2.4 (for 2.3, see the 2.x branch)
 # Cleans existing brew php (will not remove Valet stuff) + installs php on OSX!
-curl -s https://raw.githubusercontent.com/ho-nl/docker-development-box/master/install.sh | bash -s -- -i
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/ho-nl/docker-development-box/master/install.sh)"
 ```
 
 It will (re)install multiple php-fpm services, one for each version (port: 9072,


### PR DESCRIPTION
For some unknown reason (maybe https://en.wikipedia.org/wiki/System_Integrity_Protection ?), the old oneliner doesn't work anymore, and causes the `install.sh` script to quit for no apparent reason, before invoking `start_php`, breaking people's setups as it results in no php-fpm services running.

This new oneliner is what brew itself now uses, and seems to work fine.