### PR TITLE
Php8.2

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # If you're adding a new version, you need an additional XDEBUG version, not retrieved dynamically.
-PHPS='php@7.3 php@7.4 php@8.1 php@8.2'
+PHPS='php@8.2 php@8.1 php@7.4 php@7.3 php@7.2'
 
 remove_php() {
   PHP=$1
@@ -72,7 +72,7 @@ install_php() {
   XDEBUG_VERSION='3.1.6'
   [ $PHPVERSION == '8.2' ] && XDEBUG_VERSION='3.2.1'
 
-  brew link "$PHP" --force >/dev/null
+  brew link "$PHP" --overwrite >/dev/null
 
   # Use pecl upgrade, so it fails gracefully if already installed.
   $PHPDIR/bin/pecl upgrade xdebug-$XDEBUG_VERSION

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # If you're adding a new version, you need an additional XDEBUG version, not retrieved dynamically.
-PHPS='php@7.2 php@7.3 php@7.4 php@8.1 php@8.2'
+PHPS='php@7.3 php@7.4 php@8.1 php@8.2'
 
 remove_php() {
   PHP=$1

--- a/install.sh
+++ b/install.sh
@@ -72,7 +72,7 @@ install_php() {
   XDEBUG_VERSION='3.1.6'
   [ $PHPVERSION == '8.2' ] && XDEBUG_VERSION='3.2.1'
 
-  brew link "$PHP" --overwrite >/dev/null
+  brew unlink $PHP && brew link --force --overwrite $PHP > /dev/null
 
   # Use pecl upgrade, so it fails gracefully if already installed.
   $PHPDIR/bin/pecl upgrade xdebug-$XDEBUG_VERSION


### PR DESCRIPTION
This avoids this scenario:

```
┌─── hans@hansbook:~
└╼ swp81
Warning: Already linked: /opt/homebrew/Cellar/php@8.1/8.1.22
To relink, run:
  brew unlink php@8.1 && brew link --force php@8.1
┌─── hans@hansbook:~
└╼ alias swp81
alias swp81='brew link --force php@8.1'
┌─── hans@hansbook:~
└╼ brew unlink php@8.1 && brew link --force php@8.1
Unlinking /opt/homebrew/Cellar/php@8.1/8.1.22... 40 symlinks removed.
Linking /opt/homebrew/Cellar/php@8.1/8.1.22...
Error: Could not symlink bin/pear
Target /opt/homebrew/bin/pear
is a symlink belonging to php@7.2. You can unlink it:
  brew unlink php@7.2

To force the link and overwrite all conflicting files:
  brew link --overwrite php@8.1

To list all files that would be deleted:
  brew link --overwrite --dry-run php@8.1
┌─── hans@hansbook:~
└╼ brew unlink php@8.1 && brew link --force --overwrite php@8.1
Unlinking /opt/homebrew/Cellar/php@8.1/8.1.22... 0 symlinks removed.
Linking /opt/homebrew/Cellar/php@8.1/8.1.22... 337 symlinks created.

If you need to have this software first in your PATH instead consider running:
  echo 'export PATH="/opt/homebrew/opt/php@8.1/bin:$PATH"' >> /Users/hans/.bash_profile
  echo 'export PATH="/opt/homebrew/opt/php@8.1/sbin:$PATH"' >> /Users/hans/.bash_profile
```