### PR TITLE
Update docker-compose.yml with varnish fix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,14 +31,12 @@ services:
       - ./vendor/reach-digital/docker-devbox/varnish/default.vcl:/etc/varnish/default.vcl:ro
       - ./vendor/reach-digital/docker-devbox/varnish/secret:/etc/varnish/secret:ro
     ports:
-      - 6081:6081
+      - 6081:80
       - 6082:6082
-    environment:
-      VARNISH_HTTP_PORT: 6081
-      VARNISH_PROXY_PORT: 8443
     command: "-p feature=+http2 -T :6082 -S /etc/varnish/secret"
     depends_on:
       - nginx
+
 
   # phplogs: tail -f /usr/local/var/log/php*
   nginx:


### PR DESCRIPTION
This fixes problems with PURGE requests done by Magento failing, because varnish wasn't actually listening on port 6081 (but on port 80 instead).

Fixed by just mapping 6081 to 80 internally (a better fix would maybe be to make Varnish listen to the correct port, but 80 is fine too.)

Before:

```sh
 wget --method=PURGE --header="X-Magento-Tags-Pattern: .*" http://127.0.0.1:6081/
--2023-10-06 15:03:58--  http://127.0.0.1:6081/
Connecting to 127.0.0.1:6081... connected.
HTTP request sent, awaiting response... No data received.
Retrying.
```

After:

```sh
wget --method=PURGE --header="X-Magento-Tags-Pattern: .*" http://127.0.0.1:6081/
--2023-10-06 15:27:06--  http://127.0.0.1:6081/
Connecting to 127.0.0.1:6081... connected.
HTTP request sent, awaiting response... 200 Purged
Length: 240 [text/html]
Saving to: ‘index.html’

index.html                                             100%[============================================================================================================================>]     240  --.-KB/s    in 0s

2023-10-06 15:27:06 (32,7 MB/s) - ‘index.html’ saved [240/240]

$ cat index.html
<!DOCTYPE html>
<html>
  <head>
    <title>200 Purged</title>
  </head>
  <body>
    <h1>Error 200 Purged</h1>
    <p>Purged</p>
    <h3>Guru Meditation:</h3>
    <p>XID: 65544</p>
    <hr>
    <p>Varnish cache server</p>
  </body>
</html>
```