### PR TITLE
Pin mysql-client version to 8.4

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -205,7 +205,7 @@ done
 
 echo "
 Installing mysql-client, gnu-sed, pv, jq, imagemagick, pkg-config"
-brew install gnu-sed mysql-client pv jq imagemagick pkg-config &>/dev/null
+brew install gnu-sed mysql-client@8.4 pv jq imagemagick pkg-config &>/dev/null
 
 brew link mysql-client --force &>/dev/null
 


### PR DESCRIPTION
Mysql-client 9.0 removed the `mysql_native_password` authentication plugin, causing mysql-client to throw an error when trying to authenticate as a user with that specific mode of authentication