### PR TITLE
Update docker-compose.example.yml to use MySQL instead of Percona

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -68,7 +68,9 @@ services:
   #    - PARAMS=http -region=eu --authtoken=<token> nginx:80
 
   mysql:
-    image: mysql:8.0
+    # You should match the MySQL version to your production environment when
+    # setting up your project's docker-compose.yml
+    image: mysql:8.0.35
     ports:
       - 3306:3306
     environment:


### PR DESCRIPTION
Almost all customers are running on plain MySQL 8 on hypernode these days, so match this in the example file.

- Won't affect current projects (we no longer overwrite docker-compose.yml on install)
- Specific projects can always choose to use a different image, suggest matching production env.
- Discussed with Wim: we specifically set 8.0.35 as an example, to avoid new projects being setup with a 'too new' version of MySQL