### PR TITLE
feat: add Mage-OS variant of the static-content-deploy patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,9 @@ This covers initially adding docker-devbox support to a Magento project; if your
 already has docker-devbox support added, please refer to the projects' own README.
 
 - Install (and commit) this package in the project: `composer require reach-digital/docker-devbox ^5.0.0`
-- Install `static-content-deploy` [patch](patch/static-content-deploy.md) and
-  remove existing static symlinked content: `rm -rf pub/static/*/*`.
+- Install the `static-content-deploy` [patch](patch/static-content-deploy.md) (this documents both
+  the Magento and the Mage-OS variant) and remove existing static symlinked content:
+  `rm -rf pub/static/*/*`.
 - Copy the provided `docker-compose.example.yml` file to `docker-compose.yml`
   - When updating the docker-devbox package in the future, you may want to check changes in the example file to include in your project's copy.
 - Change `docker-composer.yml` as required for your project and commit this file as part of your project:

--- a/patch/mageos-static-content-deploy.diff
+++ b/patch/mageos-static-content-deploy.diff
@@ -1,0 +1,50 @@
+diff --git a/vendor/mage-os/framework/Filesystem/Driver/File.php b/vendor/mage-os/framework/Filesystem/Driver/File.php
+--- a/mage-os/framework/Filesystem/Driver/File.php	(date 1610053020000)
++++ b/mage-os/framework/Filesystem/Driver/File.php	(date 1610053020000)
+@@ -409,7 +409,7 @@
+     {
+         $result = false;
+         if ($targetDriver === null || get_class($targetDriver) == get_class($this)) {
+-            $result = @symlink($this->getScheme() . $source, $destination);
++            $result = symlink($this->relativePath($destination, $this->getScheme() . $source), $destination);
+             if ($this->stateful) {
+                 clearstatcache(true, $destination);
+             }
+@@ -429,6 +429,37 @@
+         return $result;
+     }
+ 
++    private function relativePath($basePath, $targetPath)
++    {
++        if ($basePath === $targetPath) {
++            return '';
++        }
++
++        $sourceDirs = explode('/', isset($basePath[0]) && '/' === $basePath[0] ? substr($basePath, 1) : $basePath);
++        $targetDirs = explode('/', isset($targetPath[0]) && '/' === $targetPath[0] ? substr($targetPath, 1) : $targetPath);
++        array_pop($sourceDirs);
++        $targetFile = array_pop($targetDirs);
++
++        foreach ($sourceDirs as $i => $dir) {
++                if (isset($targetDirs[$i]) && $dir === $targetDirs[$i]) {
++                        unset($sourceDirs[$i], $targetDirs[$i]);
++            } else {
++                        break;
++            }
++        }
++
++        $targetDirs[] = $targetFile;
++        $path = str_repeat('../', count($sourceDirs)).implode('/', $targetDirs);
++
++        // A reference to the same base directory or an empty subdirectory must be prefixed with "./".
++        // This also applies to a segment with a colon character (e.g., "file:colon") that cannot be used
++        // as the first segment of a relative-path reference, as it would be mistaken for a scheme name
++        // (see http://tools.ietf.org/html/rfc3986#section-4.2).
++        return '' === $path || '/' === $path[0]
++        || false !== ($colonPos = strpos($path, ':')) && ($colonPos < ($slashPos = strpos($path, '/')) || false === $slashPos)
++            ? "./$path" : $path;
++    }
++
+     /**
+      * Delete file
+      *

--- a/patch/static-content-deploy.md
+++ b/patch/static-content-deploy.md
@@ -2,21 +2,47 @@
 
 Makes the static content deploy use relative symlinks in developer mode. Does not affect production mode.
 
-Note that this patch requires Magento 2.4.2 or above. See
-https://github.com/ho-nl/docker-development-box/blob/321b50ab96dcf1a3d63b34b999dc401291e24132/patch/static-content-deploy.diff for older versions of Magento 2.
+The patch comes in two variants, which are identical apart from the framework package they target.
+Pick the one matching your project:
+
+| Project | Patch |
+| --- | --- |
+| Magento 2.4.2 or above (`magento/framework`) | `patch/static-content-deploy.diff` |
+| Mage-OS (`mage-os/framework`) | `patch/mageos-static-content-deploy.diff` |
+
+For Magento versions below 2.4.2, see
+https://github.com/ho-nl/docker-development-box/blob/321b50ab96dcf1a3d63b34b999dc401291e24132/patch/static-content-deploy.diff.
 
 ## Installation
 
 - Ensure `vaimo/composer-patches` is installed in your project.
-- Add the following to your projects' `composer.json`:
+- Add the snippet for your project below to your projects' `composer.json`.
 
-```
+### Magento
+
+```json
 {
   "extra": {
     "patches": {
       "*": {
         "Patch static-content-deploy relative symlinks": {
           "source": "./vendor/reach-digital/docker-devbox/patch/static-content-deploy.diff"
+        }
+      }
+    }
+  }
+}
+```
+
+### Mage-OS
+
+```json
+{
+  "extra": {
+    "patches": {
+      "*": {
+        "Patch static-content-deploy relative symlinks": {
+          "source": "./vendor/reach-digital/docker-devbox/patch/mageos-static-content-deploy.diff"
         }
       }
     }


### PR DESCRIPTION
## What

Mage-OS ships the framework as `mage-os/framework` instead of `magento/framework`, so the existing `static-content-deploy` patch does not apply to Mage-OS projects.

- Adds `patch/mageos-static-content-deploy.diff`, taken from the copy in use in `project-jumbosports-m2`. It is byte-identical to the existing Magento patch apart from the vendor path (verified with a `sed`-normalized diff); one blank context line that had lost its leading space in the project copy was normalized.
- Unifies the patch documentation into a single `patch/static-content-deploy.md`: a table mapping project type to patch file, the existing pre-2.4.2 pinned link, and two separate copy-pastable `composer.json` blocks (Magento / Mage-OS).
- README now points at that unified doc and mentions it covers both variants.

The filename `patch/static-content-deploy.md` is kept so existing project links and the `2.4.2-static-content-deploy.md` symlink stay valid.

## Testing

`patch -p1 --dry-run` against a real `vendor/mage-os/framework/Filesystem/Driver/File.php`: both hunks apply cleanly (offset 2 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)